### PR TITLE
Add documentation for Drace philosophy, standards, and Z-series rules

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,26 @@
+# Drace Documentation
+
+Drace is a pragmatic linter and formatter for Python.  
+It focuses on readability, maintainability, and long-term code quality rather than strict stylistic compliance.
+
+Drace does not aim to replace tools like `black` or `flake8`.  
+It aims to complement or substitute them when deeper structural feedback is desired.
+
+This documentation explains:
+- The philosophy behind Drace
+- The Darkian Standards it assumes
+- The Z-series rules and what they represent
+- How configuration and scoring work
+- Known limitations and tradeoffs
+
+## How to read these docs
+
+Recommended order:
+1. Philosophy
+2. Darkian Standards
+3. Z-Series Rules
+4. Engine Overview
+5. Configuration
+6. Scoring
+
+Each Z-rule document explains **what the rule represents and why it exists**, not how it is implemented.

--- a/docs/config.md
+++ b/docs/config.md
@@ -1,0 +1,12 @@
+# Configuration
+
+Drace supports both CLI-based and interactive configuration.
+
+## Key characteristics
+
+- Flexible separators (`=`, `:`, `::`)
+- Temporary and persistent overrides
+- Interactive, menu-driven editing
+- Human-readable configuration output
+
+Configuration is designed to be discoverable and low-friction.

--- a/docs/engine.md
+++ b/docs/engine.md
@@ -1,0 +1,12 @@
+# Linting Engine Overview
+
+Drace processes files in layered stages:
+
+1. Syntax-tolerant parsing
+2. Style and structural checks
+3. Semantic analysis
+4. Darkian rule evaluation
+
+Failures at one stage do not halt subsequent analysis.
+
+This allows Drace to provide feedback even on incomplete or broken files.

--- a/docs/philosophy.md
+++ b/docs/philosophy.md
@@ -1,0 +1,34 @@
+# Philosophy
+
+Drace is inspired by the ideas popularized in *The Pragmatic Programmer*, distilled into actionable signals rather than abstract advice.
+
+The core question Drace tries to answer is:
+
+> Will this code remain understandable and safe to change over time?
+
+Drace assumes that:
+- Code is read far more often than it is written
+- Structure communicates intent more clearly than comments
+- Visual layout affects comprehension speed
+- Small design pressures compound into large maintenance costs
+
+## Pragmatism over purity
+
+Drace prioritizes:
+- Readability over minimalism
+- Explicitness over cleverness
+- Structural clarity over stylistic conformity
+
+Rules are designed to **nudge**, not enforce ideology.  
+Most warnings indicate *pressure*, not errors.
+
+## The Z-series
+
+Z-series rules are grouped signals that reflect different dimensions of code quality:
+
+- **Z100–Z199**: Structural layout and visual consistency
+- **Z200–Z219**: Control flow density and readability
+- **Z220–Z239**: Design pressure, coupling, and cohesion
+- **Z900+**: Meta and tool-level diagnostics
+
+Each rule exists because the absence of structure eventually becomes a cost.

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -1,0 +1,13 @@
+# Z-Series Rules
+
+Each Z-series rule documents a specific design or readability pressure.
+
+Every rule description answers:
+1. What the rule targets
+2. Why that issue matters
+3. What kind of thinking it encourages
+4. What the rule explicitly does not claim
+
+Implementation details are intentionally excluded.
+
+Rules are meant to be understood, not memorized.

--- a/docs/rules/Z100.md
+++ b/docs/rules/Z100.md
@@ -1,0 +1,22 @@
+# Z100 — Assignment Alignment
+
+## What it targets
+
+Blocks of simple assignments where related variables are visually misaligned.
+
+## Why it exists
+
+Assignments often introduce or configure state.  
+When state is defined together, visual alignment improves scanning speed and comparison accuracy.
+
+## What it encourages
+
+- Treating related assignments as a single unit
+- Table-like readability for configuration blocks
+- Reduced visual friction during review
+
+## What it does NOT say
+
+- It does not require alignment everywhere
+- It ignores complex expressions
+- It does not optimize for aesthetics alone

--- a/docs/rules/Z101.md
+++ b/docs/rules/Z101.md
@@ -1,0 +1,22 @@
+# Z101 — Import Order Consistency
+
+## What it targets
+
+Import blocks that mix origins or use inconsistent ordering.
+
+## Why it exists
+
+Imports define a file’s dependency surface.  
+Predictable ordering improves orientation and reduces cognitive overhead.
+
+## What it encourages
+
+- Clear separation between standard, third-party, and local imports
+- Stable file headers across projects
+- Easier dependency auditing
+
+## What it does NOT say
+
+- It does not ban specific modules
+- It does not enforce a single universal order
+- It does not affect runtime behavior

--- a/docs/rules/Z200.md
+++ b/docs/rules/Z200.md
@@ -1,0 +1,22 @@
+# Z200 — Compact Control Blocks
+
+## What it targets
+
+Multi-line control blocks that perform only a single simple action.
+
+## Why it exists
+
+Vertical space implies complexity.  
+Unnecessarily expanded blocks suggest structure that does not exist.
+
+## What it encourages
+
+- Honest visual density
+- Reduced indentation noise
+- Clearer intent for trivial branches
+
+## What it does NOT say
+
+- It does not force one-liners
+- It respects line length limits
+- It avoids complex logic

--- a/docs/rules/Z201.md
+++ b/docs/rules/Z201.md
@@ -1,0 +1,21 @@
+# Z201 — Over-Compaction
+
+## What it targets
+
+Control flow compressed beyond reasonable readability.
+
+## Why it exists
+
+Excessive compression hides structure and increases debugging cost.
+
+## What it encourages
+
+- Balanced layout decisions
+- Letting logic expand when needed
+- Readability over density
+
+## What it does NOT say
+
+- It does not ban compact code
+- It does not enforce verbosity
+- It evaluates context before warning

--- a/docs/rules/Z202.md
+++ b/docs/rules/Z202.md
@@ -1,0 +1,21 @@
+# Z202 — Repeated Logic Detection
+
+## What it targets
+
+Semantically similar logic patterns repeated across a file or function.
+
+## Why it exists
+
+Semantic duplication is harder to detect and more dangerous than textual duplication.
+
+## What it encourages
+
+- Early abstraction
+- Naming shared intent
+- Centralizing behavior before divergence occurs
+
+## What it does NOT say
+
+- It does not force abstraction
+- It ignores trivial repetition
+- It does not assume refactoring is always required

--- a/docs/rules/Z221.md
+++ b/docs/rules/Z221.md
@@ -1,0 +1,22 @@
+# Z221 — Bloated Functions
+
+## What it targets
+
+Functions with excessive top-level structural blocks.
+
+## Why it exists
+
+Each top-level block adds a mental context switch.  
+Too many switches reduce cohesion.
+
+## What it encourages
+
+- Clear functional narratives
+- Decomposition by responsibility
+- Improved testability
+
+## What it does NOT say
+
+- It does not enforce line limits
+- It does not require micro-functions
+- It focuses on structure, not size

--- a/docs/rules/Z222.md
+++ b/docs/rules/Z222.md
@@ -1,0 +1,21 @@
+# Z222 — High External Coupling
+
+## What it targets
+
+Functions that depend on many external objects or variables.
+
+## Why it exists
+
+High coupling reduces predictability and increases change impact.
+
+## What it encourages
+
+- Explicit dependency passing
+- Narrower responsibilities
+- Improved reuse potential
+
+## What it does NOT say
+
+- It does not forbid globals
+- It allows intentional coupling
+- It flags pressure, not failure

--- a/docs/rules/Z223.md
+++ b/docs/rules/Z223.md
@@ -1,0 +1,21 @@
+# Z223 — Implicit State Mutation
+
+## What it targets
+
+Functions that modify external state without making it obvious.
+
+## Why it exists
+
+Hidden side effects break local reasoning and complicate testing.
+
+## What it encourages
+
+- Explicit mutation
+- Clear ownership of state
+- Reduced surprise for readers
+
+## What it does NOT say
+
+- It does not forbid mutation
+- It permits explicit side effects
+- It ignores local variable changes

--- a/docs/rules/Z227.md
+++ b/docs/rules/Z227.md
@@ -1,0 +1,21 @@
+# Z227 — Hidden Dependencies
+
+## What it targets
+
+Functions that rely on undeclared or implicit external names.
+
+## Why it exists
+
+Hidden dependencies make functions fragile and non-portable.
+
+## What it encourages
+
+- Explicit inputs
+- Clear dependency surfaces
+- Safer refactoring
+
+## What it does NOT say
+
+- It does not ban all globals
+- Constants are allowed
+- Built-ins are ignored

--- a/docs/scoring.md
+++ b/docs/scoring.md
@@ -1,0 +1,13 @@
+# Darkian Scoring
+
+The Darkian score is a heuristic metric representing code health.
+
+It is calculated by comparing:
+- Total lines of code
+- Number and severity of detected issues
+
+The score is intended as:
+- A trend indicator
+- A comparison tool between revisions
+
+It is not intended as an absolute measure of quality.

--- a/docs/standards.md
+++ b/docs/standards.md
@@ -1,0 +1,22 @@
+# Darkian Standards
+
+Darkian Standards are formatting and structural assumptions Drace uses internally.
+
+They are not meant to be universal rules.  
+They exist to create predictable visual structure and reduce scanning effort.
+
+## General principles
+
+- Related elements should appear visually grouped
+- Vertical structure communicates complexity
+- Alignment aids comparison
+- Noise should be minimized when meaning is simple
+
+## Examples of standards enforced
+
+- Consistent import grouping
+- Assignment alignment for simple state definitions
+- Controlled line length with readability as priority
+- Predictable block spacing
+
+These standards are configurable but form the baseline expectations of the tool.


### PR DESCRIPTION
Added a first pass at proper docs for Drace.

This covers the overall philosophy, Darkian standards, and what each Z-series rule is meant to signal. Mostly trying to make the tool’s intent clearer and easier to reason about.

Let me know if anything’s missing, misrepresented, or should be changed.
